### PR TITLE
Dev

### DIFF
--- a/toad/__init__.py
+++ b/toad/__init__.py
@@ -1,6 +1,3 @@
-import numpy
-import pyximport
-pyximport.install(setup_args={"include_dirs":numpy.get_include()})
 from .merge import merge, DTMerge, ChiMerge, StepMerge, QuantileMerge, KMeansMerge
 from .detector import detect
 from .metrics import KS, KS_bucket, F1

--- a/toad/__init__.py
+++ b/toad/__init__.py
@@ -1,3 +1,6 @@
+import numpy
+import pyximport
+pyximport.install(setup_args={"include_dirs":numpy.get_include()})
 from .merge import merge, DTMerge, ChiMerge, StepMerge, QuantileMerge, KMeansMerge
 from .detector import detect
 from .metrics import KS, KS_bucket, F1

--- a/toad/scorecard.py
+++ b/toad/scorecard.py
@@ -283,7 +283,7 @@ class ScoreCard(BaseEstimator, RulesMixin, BinsMixin):
             # organize into list of tuple
             reason = [(f, f'{ss:+.1f}', raw) for f, bias, ss, raw in dimensions]
 
-            # scores.append(row_total_score)
+            scores.append(row_total_score)
             reasons.append(reason)
         if return_sub:  # caution, scalar-version returns dict/list instead of DataFrames
             return scores, sub_scores, reasons

--- a/toad/scorecard_test.py
+++ b/toad/scorecard_test.py
@@ -306,7 +306,7 @@ def test_card_with_less_X():
 sub_df_for_vector = df.iloc[[404, 410]]
 
 
-def test_get_score_reason_vector():
+def test_get_reason_vector():
     """
     verify the score reason of df is consistent with assumption
     DF_REASON is manually calculated with following logic:
@@ -322,7 +322,7 @@ def test_get_score_reason_vector():
         which is larger than base, hence, we try to find top `keep` features who contributed most to positivity
     find_largest_top_3:  A(+9) B(+6) D(+0)
     """
-    pred, sub_score, reason = card.predict(sub_df_for_vector, return_sub=True, return_reason=True)
+    reason = card.get_reason(sub_df_for_vector)
     # list of tuple
     # the list has length `keep`, which means the top `keep` features who contributed most
     # the tuple means tuple of <feature_name, sub_score, raw_value>
@@ -332,13 +332,8 @@ def test_get_score_reason_vector():
 rows_for_scalar = df.iloc[[404]].to_dict(orient='records')  # use list for scalar-loop
 
 
-def test_get_score_reason_scalar():
-    pred, sub_score, reason = card.predict(rows_for_scalar, return_sub=True, return_reason=True)
-    assert pred == pytest.approx([453.5491351039002])
-    # print(sub_score) as follows
-    #     {'A': np.array([151.35825557]), 'B': np.array([159.23912912]),
-    #      'C': np.array([142.95175042]), 'D': np.array([0])})
-    assert sub_score['A'] == pytest.approx([151.35825557])
+def test_get_reason_scalar():
+    reason = card.get_reason(rows_for_scalar)
     # list of list of tuple
     # the outer-most list has length batch_size
     # the list-in-middle has length `keep`, which means the top `keep` features who contributed most
@@ -347,18 +342,18 @@ def test_get_score_reason_scalar():
 
 
 @pytest.mark.timeout(0.030)
-def test_get_score_reason_vector_wide():
+def test_get_reason_vector_wide():
     """ a test for vector inference time cost """
     # prepare wide dataframe for vector inference
     df_wide = pd.DataFrame(samples_in_wide_dict)
-    pred, sub_score, reason = card_wide.predict(df_wide, return_sub=True, return_reason=True)
+    reason = card_wide.get_reason(df_wide)
     assert True
 
 
 @pytest.mark.timeout(0.004)
-def test_get_score_reason_scalar_wide():
+def test_get_reason_scalar_wide():
     """ a test for scalar inference time cost """
-    pred, sub_score, reason = card_wide.predict(samples_in_wide_dict, return_sub=True, return_reason=True)
+    reason = card_wide.get_reason(samples_in_wide_dict)
     assert True
 
 

--- a/toad/scorecard_test.py
+++ b/toad/scorecard_test.py
@@ -341,7 +341,23 @@ def test_get_reason_scalar():
     assert reason == [[('A', '+151.4', 3), ('B', '+159.2', 'D'), ('D', '+0.0', 1.0)]]
 
 
-@pytest.mark.timeout(0.030)
+@pytest.mark.timeout(0.021)
+def test_predict_vector_wide():
+    """ a test for vector inference time cost """
+    # prepare wide dataframe for vector inference
+    df_wide = pd.DataFrame(samples_in_wide_dict)
+    proba = card_wide.predict_proba(df_wide)
+    assert True
+
+
+@pytest.mark.timeout(0.007)
+def test_predict_scalar_wide():
+    """ a test for scalar inference time cost """
+    proba = card_wide.predict_proba(samples_in_wide_dict)
+    assert True
+
+
+@pytest.mark.timeout(0.040)
 def test_get_reason_vector_wide():
     """ a test for vector inference time cost """
     # prepare wide dataframe for vector inference
@@ -350,7 +366,7 @@ def test_get_reason_vector_wide():
     assert True
 
 
-@pytest.mark.timeout(0.004)
+@pytest.mark.timeout(0.005)
 def test_get_reason_scalar_wide():
     """ a test for scalar inference time cost """
     reason = card_wide.get_reason(samples_in_wide_dict)


### PR DESCRIPTION
已经将`get_reason()`与 `predict()`解耦开。  
已经按要求，重新 merge 一下 dev 分支再提交一下，触发一下自动测试。

补充下述两个小的功能增强，麻烦审核一下；希望能尽快合入新的版本发布到pip源可用。感谢！

1. 支持top加减分维度的展示，提供更好的解释性。参考了这里的Effect Plot思路 https://christophm.github.io/interpretable-ml-book/limo.html#effect-plot  展示的top-effects-as-reason，形如 `[('A', '+151.4', 3), ('B', '+159.2', 'D'), ('D', '+0.0', 1.0)]` 表示 `A`特征维度的原始取值为`3`导致加分`+151.4`，`B`维度.. 依次类推。排序是按照 effect对照该维度median的偏离程度降序的，所以这里虽然 151.4 < 159.2 但是A仍然排在了B的前面；如果到单测代码中观察bias会发现A_bias是+9，B_bias是+6。这种机制比单纯看sub_score的大小更符合业务直觉。
2. 支持标量推断（规避pandas耗时）以便加速(30ms -> 4ms)。线上业务传入的通常就是代表单个样本的dict，如果组织成DataFrame再推断，容易超时。因此对整个推理过程做了标量推断的适配，在各个环节都兼容dict的格式。