### PR TITLE
Add ChiMerge constraint mode

### DIFF
--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,9 +1,76 @@
 use pyo3::prelude::*;
+use pyo3::exceptions::PyValueError;
 use numpy::{PyArray1, PyReadonlyArray1};
 use ndarray::{Array1, Array2, Axis, s};
 use std::collections::HashSet;
 
 const DEFAULT_BINS: usize = 10;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ConstraintMode {
+    Any,
+    All,
+}
+
+impl ConstraintMode {
+    fn parse(mode: &str) -> PyResult<Self> {
+        match mode {
+            "any" => Ok(Self::Any),
+            "all" => Ok(Self::All),
+            _ => Err(PyValueError::new_err(
+                "`constraint_mode` must be either 'any' or 'all'",
+            )),
+        }
+    }
+}
+
+fn min_row_count(grouped: &Array2<f64>) -> f64 {
+    let row_sums = grouped.sum_axis(Axis(1));
+    row_sums
+        .iter()
+        .fold(f64::INFINITY, |current_min, &count| current_min.min(count))
+}
+
+fn should_break(
+    grouped: &Array2<f64>,
+    n_bins: Option<usize>,
+    min_samples_val: Option<f64>,
+    constraint_mode: ConstraintMode,
+) -> bool {
+    match constraint_mode {
+        ConstraintMode::Any => {
+            if let Some(nb) = n_bins {
+                if grouped.nrows() <= nb {
+                    return true;
+                }
+            }
+
+            if let Some(ms_val) = min_samples_val {
+                if min_row_count(grouped) > ms_val {
+                    return true;
+                }
+            }
+
+            false
+        }
+        ConstraintMode::All => {
+            let mut has_hard_constraint = false;
+            let mut satisfied = true;
+
+            if let Some(nb) = n_bins {
+                has_hard_constraint = true;
+                satisfied &= grouped.nrows() <= nb;
+            }
+
+            if let Some(ms_val) = min_samples_val {
+                has_hard_constraint = true;
+                satisfied &= min_row_count(grouped) >= ms_val;
+            }
+
+            has_hard_constraint && satisfied
+        }
+    }
+}
 
 /// Helper function to fill NaN values
 fn fill_nan(arr: &Array1<f64>, fill_value: f64) -> Array1<f64> {
@@ -20,7 +87,7 @@ fn unique_sorted_f64(arr: &Array1<f64>) -> Vec<f64> {
 
 /// ChiMerge - Chi-square based merging (core algorithm in Rust)
 #[pyfunction]
-#[pyo3(signature = (feature, target, n_bins=None, min_samples=None, min_threshold=None, nan=-1.0, balance=true))]
+#[pyo3(signature = (feature, target, n_bins=None, min_samples=None, min_threshold=None, nan=-1.0, balance=true, constraint_mode="any"))]
 fn chi_merge<'py>(
     py: Python<'py>,
     feature: PyReadonlyArray1<f64>,
@@ -30,7 +97,16 @@ fn chi_merge<'py>(
     min_threshold: Option<f64>,
     nan: f64,
     balance: bool,
+    constraint_mode: &str,
 ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+    let constraint_mode = ConstraintMode::parse(constraint_mode)?;
+
+    if constraint_mode == ConstraintMode::All && n_bins.is_none() && min_samples.is_none() {
+        return Err(PyValueError::new_err(
+            "`constraint_mode='all'` requires `n_bins` and/or `min_samples`; `min_threshold` is ignored in this mode",
+        ));
+    }
+
     // Set default break condition
     let n_bins = if n_bins.is_none() && min_samples.is_none() && min_threshold.is_none() {
         Some(DEFAULT_BINS)
@@ -81,20 +157,8 @@ fn chi_merge<'py>(
 
     // Merge loop
     loop {
-        // Break if n_bins reached
-        if let Some(nb) = n_bins {
-            if grouped.nrows() <= nb {
-                break;
-            }
-        }
-
-        // Break if min_samples reached
-        if let Some(ms_val) = min_samples_val {
-            let row_sums = grouped.sum_axis(Axis(1));
-            let min_count = row_sums.iter().fold(f64::INFINITY, |a, &b| a.min(b));
-            if min_count > ms_val {
-                break;
-            }
+        if should_break(&grouped, n_bins, min_samples_val, constraint_mode) {
+            break;
         }
 
         // Calculate chi-square for each adjacent group pair
@@ -131,10 +195,12 @@ fn chi_merge<'py>(
             }
         }
 
-        // Break if min_threshold reached
-        if let Some(mt) = min_threshold {
-            if chi_min > mt {
-                break;
+        // Legacy mode keeps min_threshold as an independent stopping condition.
+        if constraint_mode == ConstraintMode::Any {
+            if let Some(mt) = min_threshold {
+                if chi_min > mt {
+                    break;
+                }
             }
         }
 

--- a/src/merge_generic.rs
+++ b/src/merge_generic.rs
@@ -1,8 +1,75 @@
 use pyo3::prelude::*;
+use pyo3::exceptions::PyValueError;
 use numpy::{PyArray1, PyReadonlyArray1, Element};
 use ndarray::{Array1, Array2, Axis, s};
 use std::collections::HashSet;
 use num_traits::{Num, NumCast};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ConstraintMode {
+    Any,
+    All,
+}
+
+impl ConstraintMode {
+    fn parse(mode: &str) -> PyResult<Self> {
+        match mode {
+            "any" => Ok(Self::Any),
+            "all" => Ok(Self::All),
+            _ => Err(PyValueError::new_err(
+                "`constraint_mode` must be either 'any' or 'all'",
+            )),
+        }
+    }
+}
+
+fn min_row_count(grouped: &Array2<f64>) -> f64 {
+    let row_sums = grouped.sum_axis(Axis(1));
+    row_sums
+        .iter()
+        .fold(f64::INFINITY, |current_min, &count| current_min.min(count))
+}
+
+fn should_break(
+    grouped: &Array2<f64>,
+    n_bins: Option<usize>,
+    min_samples_val: Option<f64>,
+    constraint_mode: ConstraintMode,
+) -> bool {
+    match constraint_mode {
+        ConstraintMode::Any => {
+            if let Some(nb) = n_bins {
+                if grouped.nrows() <= nb {
+                    return true;
+                }
+            }
+
+            if let Some(ms_val) = min_samples_val {
+                if min_row_count(grouped) > ms_val {
+                    return true;
+                }
+            }
+
+            false
+        }
+        ConstraintMode::All => {
+            let mut has_hard_constraint = false;
+            let mut satisfied = true;
+
+            if let Some(nb) = n_bins {
+                has_hard_constraint = true;
+                satisfied &= grouped.nrows() <= nb;
+            }
+
+            if let Some(ms_val) = min_samples_val {
+                has_hard_constraint = true;
+                satisfied &= min_row_count(grouped) >= ms_val;
+            }
+
+            has_hard_constraint && satisfied
+        }
+    }
+}
 
 /// Helper function to fill NaN values for floating point types
 fn fill_nan_f64(arr: &Array1<f64>, fill_value: f64) -> Array1<f64> {
@@ -34,6 +101,7 @@ fn chi_merge_generic<T>(
     min_threshold: Option<f64>,
     _nan: f64,
     balance: bool,
+    constraint_mode: ConstraintMode,
 ) -> PyResult<Vec<T>>
 where
     T: Num + NumCast + Copy + PartialOrd + std::fmt::Display + Element + 'static,
@@ -88,26 +156,16 @@ where
 
     // Merge loop
     loop {
-        // Break if n_bins reached
-        if let Some(nb) = n_bins {
-            if grouped.nrows() <= nb {
-                break;
-            }
-        }
-
-        // Break if min_samples reached
-        if let Some(ms_val) = min_samples.map(|ms| {
+        let min_samples_val = min_samples.map(|ms| {
             if ms < 1.0 {
                 (feature_filled.len() as f64) * ms
             } else {
                 ms as f64
             }
-        }) {
-            let row_sums = grouped.sum_axis(Axis(1));
-            let min_count = row_sums.iter().fold(f64::INFINITY, |a, &b| a.min(b));
-            if min_count > ms_val {
-                break;
-            }
+        });
+
+        if should_break(&grouped, n_bins, min_samples_val, constraint_mode) {
+            break;
         }
 
         // Calculate chi-square for each adjacent group pair
@@ -144,10 +202,12 @@ where
             }
         }
 
-        // Break if min_threshold reached
-        if let Some(mt) = min_threshold {
-            if chi_min > mt {
-                break;
+        // Legacy mode keeps min_threshold as an independent stopping condition.
+        if constraint_mode == ConstraintMode::Any {
+            if let Some(mt) = min_threshold {
+                if chi_min > mt {
+                    break;
+                }
             }
         }
 
@@ -192,7 +252,7 @@ where
 
 /// ChiMerge for f64 (floating point)
 #[pyfunction]
-#[pyo3(signature = (feature, target, n_bins=None, min_samples=None, min_threshold=None, nan=0.0, balance=false))]
+#[pyo3(signature = (feature, target, n_bins=None, min_samples=None, min_threshold=None, nan=0.0, balance=false, constraint_mode="any"))]
 pub fn chi_merge_f64<'py>(
     py: Python<'py>,
     feature: PyReadonlyArray1<f64>,
@@ -202,14 +262,32 @@ pub fn chi_merge_f64<'py>(
     min_threshold: Option<f64>,
     nan: f64,
     balance: bool,
+    constraint_mode: &str,
 ) -> PyResult<Bound<'py, PyArray1<f64>>> {
-    let splits = chi_merge_generic(feature, target, n_bins, min_samples, min_threshold, nan, balance)?;
+    let constraint_mode = ConstraintMode::parse(constraint_mode)?;
+
+    if constraint_mode == ConstraintMode::All && n_bins.is_none() && min_samples.is_none() {
+        return Err(PyValueError::new_err(
+            "`constraint_mode='all'` requires `n_bins` and/or `min_samples`; `min_threshold` is ignored in this mode",
+        ));
+    }
+
+    let splits = chi_merge_generic(
+        feature,
+        target,
+        n_bins,
+        min_samples,
+        min_threshold,
+        nan,
+        balance,
+        constraint_mode,
+    )?;
     Ok(PyArray1::from_vec_bound(py, splits))
 }
 
 /// ChiMerge for i32 (integer)
 #[pyfunction]
-#[pyo3(signature = (feature, target, n_bins=None, min_samples=None, min_threshold=None, nan=0, balance=false))]
+#[pyo3(signature = (feature, target, n_bins=None, min_samples=None, min_threshold=None, nan=0, balance=false, constraint_mode="any"))]
 pub fn chi_merge_i32<'py>(
     py: Python<'py>,
     feature: PyReadonlyArray1<i32>,
@@ -219,14 +297,32 @@ pub fn chi_merge_i32<'py>(
     min_threshold: Option<f64>,
     nan: i32,
     balance: bool,
+    constraint_mode: &str,
 ) -> PyResult<Bound<'py, PyArray1<i32>>> {
-    let splits = chi_merge_generic(feature, target, n_bins, min_samples, min_threshold, nan as f64, balance)?;
+    let constraint_mode = ConstraintMode::parse(constraint_mode)?;
+
+    if constraint_mode == ConstraintMode::All && n_bins.is_none() && min_samples.is_none() {
+        return Err(PyValueError::new_err(
+            "`constraint_mode='all'` requires `n_bins` and/or `min_samples`; `min_threshold` is ignored in this mode",
+        ));
+    }
+
+    let splits = chi_merge_generic(
+        feature,
+        target,
+        n_bins,
+        min_samples,
+        min_threshold,
+        nan as f64,
+        balance,
+        constraint_mode,
+    )?;
     Ok(PyArray1::from_vec_bound(py, splits))
 }
 
 /// ChiMerge for i64 (integer)
 #[pyfunction]
-#[pyo3(signature = (feature, target, n_bins=None, min_samples=None, min_threshold=None, nan=0, balance=false))]
+#[pyo3(signature = (feature, target, n_bins=None, min_samples=None, min_threshold=None, nan=0, balance=false, constraint_mode="any"))]
 pub fn chi_merge_i64<'py>(
     py: Python<'py>,
     feature: PyReadonlyArray1<i64>,
@@ -236,7 +332,25 @@ pub fn chi_merge_i64<'py>(
     min_threshold: Option<f64>,
     nan: i64,
     balance: bool,
+    constraint_mode: &str,
 ) -> PyResult<Bound<'py, PyArray1<i64>>> {
-    let splits = chi_merge_generic(feature, target, n_bins, min_samples, min_threshold, nan as f64, balance)?;
+    let constraint_mode = ConstraintMode::parse(constraint_mode)?;
+
+    if constraint_mode == ConstraintMode::All && n_bins.is_none() && min_samples.is_none() {
+        return Err(PyValueError::new_err(
+            "`constraint_mode='all'` requires `n_bins` and/or `min_samples`; `min_threshold` is ignored in this mode",
+        ));
+    }
+
+    let splits = chi_merge_generic(
+        feature,
+        target,
+        n_bins,
+        min_samples,
+        min_threshold,
+        nan as f64,
+        balance,
+        constraint_mode,
+    )?;
     Ok(PyArray1::from_vec_bound(py, splits))
 }

--- a/toad/impute.py
+++ b/toad/impute.py
@@ -1,10 +1,8 @@
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_numeric_dtype
 from sklearn.experimental import enable_iterative_imputer
 from sklearn.impute import IterativeImputer
 from sklearn.ensemble import RandomForestRegressor
-from sklearn.preprocessing import LabelEncoder
 
 
 
@@ -62,12 +60,18 @@ class Imputer(IterativeImputer):
             X (DataFrame)
             mask (Mask): empty mask for X
         """
+        X = X.copy()
         category_data = X.select_dtypes(exclude = np.number).columns
         
         for col in category_data:
-            unique, X[col].loc[~mask[col]] = np.unique(X[col][~mask[col]], return_inverse = True)
+            valid_mask = ~mask[col]
+            values = X.loc[valid_mask, col].to_numpy(dtype = object)
+            unique, encoded = np.unique(values, return_inverse = True)
 
             self.encoder_dict[col] = unique
+            encoded_col = pd.Series(np.nan, index = X.index, dtype = float)
+            encoded_col.loc[valid_mask] = encoded.astype(float)
+            X[col] = encoded_col
         
         return X
 
@@ -78,9 +82,14 @@ class Imputer(IterativeImputer):
             X (DataFrame)
             mask (Mask): empty mask for X
         """
+        X = X.copy()
         for col, unique in self.encoder_dict.items():
+            valid_mask = ~mask[col]
             table = dict(zip(unique, np.arange(len(unique))))
-            X[col].loc[~mask[col]] = np.array([table[v] for v in X[col][~mask[col]]])
+            encoded_col = pd.Series(np.nan, index = X.index, dtype = float)
+            values = X.loc[valid_mask, col].to_numpy(dtype = object)
+            encoded_col.loc[valid_mask] = np.array([table[v] for v in values], dtype = float)
+            X[col] = encoded_col
         
         return X
     

--- a/toad/merge.py
+++ b/toad/merge.py
@@ -42,6 +42,19 @@ except ImportError as e:
 DEFAULT_BINS = 10
 
 
+def _validate_constraint_mode(constraint_mode, n_bins=None, min_samples=None):
+    if constraint_mode not in ('any', 'all'):
+        raise ValueError("`constraint_mode` must be either 'any' or 'all'")
+
+    if constraint_mode == 'all' and n_bins is None and min_samples is None:
+        raise ValueError(
+            "`constraint_mode='all'` requires `n_bins` and/or `min_samples`; "
+            "`min_threshold` is ignored in this mode"
+        )
+
+    return constraint_mode
+
+
 def StepMerge(feature, nan=None, n_bins=None, clip_v=None, clip_std=None, clip_q=None):
     """Merge by step
 
@@ -163,7 +176,8 @@ def DTMerge(feature, target, nan=-1, n_bins=None, min_samples=1, **kwargs):
 # If not available, provide a fallback
 if _chi_merge_rust is None:
     def ChiMerge(feature, target, n_bins=None, min_samples=None,
-                min_threshold=None, nan=-1, balance=True):
+                min_threshold=None, nan=-1, balance=True,
+                constraint_mode='any'):
         """Chi-Merge (Python fallback)
 
         Note: This is a fallback implementation. For better performance,
@@ -175,10 +189,17 @@ if _chi_merge_rust is None:
             n_bins (int): n bins will be merged into
             min_samples (number): min sample in each group, if float, it will be the percentage of samples
             min_threshold (number): min threshold of chi-square
+            constraint_mode (str): 'any' keeps legacy stop behavior, 'all'
+                requires all provided hard constraints to be satisfied
 
         Returns:
             array: array of split points
         """
+        _validate_constraint_mode(
+            constraint_mode,
+            n_bins=n_bins,
+            min_samples=min_samples,
+        )
         raise NotImplementedError(
             "ChiMerge Rust implementation not available. "
             "Please build the Rust extension with: maturin develop"
@@ -186,7 +207,8 @@ if _chi_merge_rust is None:
 else:
     # Wrap Rust implementation with type conversion
     def ChiMerge(feature, target, n_bins=None, min_samples=None,
-                min_threshold=None, nan=-1, balance=True):
+                min_threshold=None, nan=-1, balance=True,
+                constraint_mode='any'):
         """Chi-Merge using Rust implementation
 
         Args:
@@ -197,10 +219,18 @@ else:
             min_threshold (number): min threshold of chi-square
             nan (number): value to replace NaN
             balance (bool): whether to balance chi-square by group size
+            constraint_mode (str): 'any' keeps legacy stop behavior, 'all'
+                requires all provided hard constraints to be satisfied
 
         Returns:
             array: array of split points
         """
+        _validate_constraint_mode(
+            constraint_mode,
+            n_bins=n_bins,
+            min_samples=min_samples,
+        )
+
         # Convert to numpy arrays without forcing dtype conversion
         feature_arr = to_ndarray(feature)
         target_arr = to_ndarray(target).astype(np.int32)
@@ -214,7 +244,8 @@ else:
                 min_samples=min_samples,
                 min_threshold=min_threshold,
                 nan=float(nan),
-                balance=balance
+                balance=balance,
+                constraint_mode=constraint_mode
             )
         elif _chi_merge_rust_i32 is not None and np.issubdtype(feature_arr.dtype, np.integer) and feature_arr.dtype in [np.int32]:
             # Use i32 version for int32 data
@@ -224,7 +255,8 @@ else:
                 min_samples=min_samples,
                 min_threshold=min_threshold,
                 nan=int(nan),
-                balance=balance
+                balance=balance,
+                constraint_mode=constraint_mode
             )
         elif _chi_merge_rust_i64 is not None and np.issubdtype(feature_arr.dtype, np.integer):
             # Use i64 version for integer data (default for integers)
@@ -234,7 +266,8 @@ else:
                 min_samples=min_samples,
                 min_threshold=min_threshold,
                 nan=int(nan),
-                balance=balance
+                balance=balance,
+                constraint_mode=constraint_mode
             )
         else:
             # Fallback to original implementation for compatibility
@@ -246,7 +279,8 @@ else:
                 min_samples=min_samples,
                 min_threshold=min_threshold,
                 nan=nan,
-                balance=balance
+                balance=balance,
+                constraint_mode=constraint_mode
             )
 
 

--- a/toad/merge_test.py
+++ b/toad/merge_test.py
@@ -2,9 +2,13 @@ import pytest
 import numpy as np
 import pandas as pd
 
-import pyximport
+try:
+    import pyximport
+except ModuleNotFoundError:
+    pyximport = None
 
-pyximport.install(setup_args={"include_dirs": np.get_include()})
+if pyximport is not None:
+    pyximport.install(setup_args={"include_dirs": np.get_include()})
 
 from .merge import merge, ChiMerge, DTMerge, QuantileMerge, StepMerge, KMeansMerge
 
@@ -21,6 +25,53 @@ df = pd.DataFrame({
 })
 
 
+def _bin_counts(feature, splits):
+    bins = np.digitize(feature, splits, right = False)
+    return np.bincount(bins.astype(int))
+
+
+def _make_constraint_case_a():
+    counts = np.array([41, 34, 22, 24, 10, 11, 8, 17, 50, 41, 55])
+    probs = np.array([
+        0.19128, 0.24629567, 0.21073853, 0.2514205, 0.37637079,
+        0.50289282, 0.41724785, 0.64468458, 0.65278623, 0.76874129,
+        0.86190187,
+    ])
+    rng = np.random.default_rng(0)
+
+    feature = np.concatenate([
+        np.full(count, i, dtype = float)
+        for i, count in enumerate(counts)
+    ])
+    target = np.concatenate([
+        rng.binomial(1, prob, size = count)
+        for count, prob in zip(counts, probs)
+    ])
+
+    return feature, target
+
+
+def _make_constraint_case_b():
+    counts = np.array([26, 21, 12, 13, 3, 4, 2, 8, 32, 26, 36, 21])
+    probs = np.array([
+        0.23941619, 0.01, 0.01, 0.17079965, 0.38553792, 0.01,
+        0.49715076, 0.37354508, 0.55809198, 0.67751184, 0.80492179,
+        0.99,
+    ])
+    rng = np.random.default_rng(0)
+
+    feature = np.concatenate([
+        np.full(count, i, dtype = float)
+        for i, count in enumerate(counts)
+    ])
+    target = np.concatenate([
+        rng.binomial(1, prob, size = count)
+        for count, prob in zip(counts, probs)
+    ])
+
+    return feature, target
+
+
 
 def test_chimerge():
     splits = ChiMerge(feature, target, n_bins = 10)
@@ -33,6 +84,72 @@ def test_chimerge_bins_not_enough():
 def test_chimerge_bins_with_min_samples():
     splits = ChiMerge(feature, target, min_samples = 0.02)
     assert len(splits) == 10
+
+def test_chimerge_constraint_mode_all_matches_any_with_only_n_bins():
+    case_feature, case_target = _make_constraint_case_a()
+    splits_any = ChiMerge(case_feature, case_target, n_bins = 4, constraint_mode = 'any')
+    splits_all = ChiMerge(case_feature, case_target, n_bins = 4, constraint_mode = 'all')
+
+    np.testing.assert_array_equal(splits_any, splits_all)
+
+def test_chimerge_constraint_mode_all_matches_any_with_only_min_samples():
+    case_feature, case_target = _make_constraint_case_a()
+    splits_any = ChiMerge(case_feature, case_target, min_samples = 0.051, constraint_mode = 'any')
+    splits_all = ChiMerge(case_feature, case_target, min_samples = 0.051, constraint_mode = 'all')
+
+    np.testing.assert_array_equal(splits_any, splits_all)
+
+def test_chimerge_constraint_mode_all_requires_n_bins_and_min_samples():
+    case_feature, case_target = _make_constraint_case_a()
+    min_samples = 0.05
+    splits_any = ChiMerge(case_feature, case_target, n_bins = 3, min_samples = min_samples, constraint_mode = 'any')
+    splits_all = ChiMerge(case_feature, case_target, n_bins = 3, min_samples = min_samples, constraint_mode = 'all')
+
+    counts_any = _bin_counts(case_feature, splits_any)
+    counts_all = _bin_counts(case_feature, splits_all)
+    threshold = len(case_feature) * min_samples
+
+    assert len(splits_any) + 1 > 3
+    assert counts_any.min() > threshold
+    assert len(splits_all) + 1 <= 3
+    assert counts_all.min() >= threshold
+
+def test_chimerge_constraint_mode_all_keeps_merging_when_small_bins_remain():
+    case_feature, case_target = _make_constraint_case_b()
+    min_samples = 0.12
+    splits_any = ChiMerge(case_feature, case_target, n_bins = 3, min_samples = min_samples, constraint_mode = 'any')
+    splits_all = ChiMerge(case_feature, case_target, n_bins = 3, min_samples = min_samples, constraint_mode = 'all')
+
+    counts_any = _bin_counts(case_feature, splits_any)
+    counts_all = _bin_counts(case_feature, splits_all)
+    threshold = len(case_feature) * min_samples
+
+    assert len(splits_any) + 1 <= 3
+    assert counts_any.min() < threshold
+    assert len(splits_all) + 1 <= 3
+    assert counts_all.min() >= threshold
+
+def test_chimerge_constraint_mode_all_ignores_min_threshold_stop():
+    case_feature, case_target = _make_constraint_case_a()
+    splits_any = ChiMerge(
+        case_feature,
+        case_target,
+        n_bins = 3,
+        min_samples = 0.05,
+        min_threshold = -1.0,
+        constraint_mode = 'any',
+    )
+    splits_all = ChiMerge(
+        case_feature,
+        case_target,
+        n_bins = 3,
+        min_samples = 0.05,
+        min_threshold = -1.0,
+        constraint_mode = 'all',
+    )
+
+    assert len(splits_any) + 1 > 3
+    assert len(splits_all) + 1 <= 3
 
 def test_dtmerge():
     splits = DTMerge(feature, target, n_bins = 10)

--- a/toad/transform.py
+++ b/toad/transform.py
@@ -188,6 +188,8 @@ class Combiner(Transformer, BinsMixin):
             method (str): the strategy to be used to merge `X`, same as `.merge`, default is `chi`
             n_bins (int): counts of bins will be combined
             empty_separate (bool): if need to combine empty values into a separate group
+            **kwargs: forwarded to the underlying merge method, such as
+                `constraint_mode` for `method='chi'`
         """
         from .merge import merge
         

--- a/toad/transform_test.py
+++ b/toad/transform_test.py
@@ -2,9 +2,13 @@ import pytest
 import numpy as np
 import pandas as pd
 
-import pyximport
+try:
+    import pyximport
+except ModuleNotFoundError:
+    pyximport = None
 
-pyximport.install(setup_args={"include_dirs": np.get_include()})
+if pyximport is not None:
+    pyximport.install(setup_args={"include_dirs": np.get_include()})
 
 from .transform import WOETransformer, Combiner, GBDTTransformer
 
@@ -25,6 +29,30 @@ df = pd.DataFrame({
     'D': empty_feat,
     'target': target,
 })
+
+
+def _make_constraint_case_a_with_missing():
+    counts = np.array([41, 34, 22, 24, 10, 11, 8, 17, 50, 41, 55])
+    probs = np.array([
+        0.19128, 0.24629567, 0.21073853, 0.2514205, 0.37637079,
+        0.50289282, 0.41724785, 0.64468458, 0.65278623, 0.76874129,
+        0.86190187,
+    ])
+    rng = np.random.default_rng(0)
+
+    feature = np.concatenate([
+        np.full(count, i, dtype = float)
+        for i, count in enumerate(counts)
+    ])
+    target = np.concatenate([
+        rng.binomial(1, prob, size = count)
+        for count, prob in zip(counts, probs)
+    ])
+
+    feature = np.concatenate([feature, np.full(5, np.nan)])
+    target = np.concatenate([target, np.array([0, 1, 0, 1, 0])])
+
+    return pd.Series(feature, name = 'E'), target
 
 
 
@@ -161,6 +189,29 @@ def test_combiner_labels_with_empty():
     combiner = Combiner().fit(df, 'target', n_bins = 4, empty_separate = True)
     res = combiner.transform(df, labels = True)
     assert res.loc[2, 'D'] == '04.nan'
+
+def test_combiner_empty_separate_with_constraint_mode_all():
+    series, series_target = _make_constraint_case_a_with_missing()
+    combiner = Combiner().fit(
+        series,
+        series_target,
+        n_bins = 3,
+        min_samples = 0.05,
+        constraint_mode = 'all',
+        empty_separate = True,
+    )
+
+    rule = combiner.rules['E']
+    transformed = combiner.transform(series)
+    mask = pd.isna(series)
+    non_missing_counts = np.bincount(transformed[~mask].astype(int))
+    threshold = (~mask).sum() * 0.05
+
+    assert np.isnan(rule[-1])
+    assert len(rule[:-1]) + 1 <= 3
+    assert non_missing_counts.min() >= threshold
+    assert mask.sum() < threshold
+    assert (transformed[mask] == len(rule)).all()
 
 def test_gbdt_transformer():
     np.random.seed(1)


### PR DESCRIPTION
**这个 PR 为 ChiMerge 增加了一个兼容式新参数 constraint_mode。**

Fixes #12 


若在fit中选择‘chi’, 且同时设置min_sample参数和n_bins参数，ChiMerge的逻辑：在满足其中一个条件后就break
<img width="1310" height="634" alt="d95327b017333d1f4a178711778499aa" src="https://github.com/user-attachments/assets/2bb2a208-c901-4f73-a69c-d56f72ba851e" />

例如设置参数n_bins = 5, min_samples=0.04（1.原意是希望分箱结果同时满足两个条件；2.此参数设置是合法且可行的），分箱会出现以下情况（以下图片的模拟数据集来源 https://www.kaggle.com/competitions/gmsc-thebridge-dsft2109/data ）：

1.先满足 min_samples，此时虽然每箱样本占比都足够大，但箱数仍然大于 n_bins，算法却提前停止。
<img width="1384" height="483" alt="image" src="https://github.com/user-attachments/assets/a8cf490b-237d-4a67-ac87-f17f4ec077a8" />

2.先满足 n_bins，此时箱数已经不超过目标，但仍存在极小箱，算法也会提前停止。
<img width="1384" height="484" alt="image" src="https://github.com/user-attachments/assets/1b22b239-223f-4c25-9223-abbf5c9c563f" />



**此PR新增constraint_mode**，将这个参数从 Python 包装层一路透传到了 Rust 的 ChiMerge 核心逻辑，并在 all 模式下保留了 empty_separate=True 的现有语义。默认 constraint_mode='any' 保持旧行为不变，也就是 n_bins、min_samples、min_threshold 任一条件满足就停止；新增的 constraint_mode='all' 则把 n_bins 和 min_samples 当作硬约束，只有“箱数 <= n_bins”且“每个普通箱样本数/占比 >= min_samples”同时满足时才停止。
<img width="2574" height="330" alt="image" src="https://github.com/user-attachments/assets/9317196e-b3c5-4d17-8023-6ba0b5993a94" />

改动后同参数同特征的分箱结果如图所示：
<img width="1384" height="483" alt="image" src="https://github.com/user-attachments/assets/d2c987e0-d5e0-4b6c-bdac-64f18e218069" />

<img width="1384" height="484" alt="image" src="https://github.com/user-attachments/assets/fce366d6-db46-434c-bf4f-c53a863a8c89" />

测试了修改的部分
<img width="1698" height="744" alt="image" src="https://github.com/user-attachments/assets/75fbe66f-bbd4-448f-810d-78401cc65399" />
