### PR TITLE
fix: pandas compat in impute.py, update CI runners and Python versions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,10 +11,10 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         experimental: [false]
         include:
-          - python-version: '3.13'
+          - python-version: '3.14'
             experimental: true
       fail-fast: false
     runs-on: ubuntu-latest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        macos-version: ['macos-13', 'macos-latest']  # macos-13: Intel, macos-latest: Apple Silicon
+        macos-version: ['macos-14', 'macos-latest']  # macos-14: Intel(x86_64), macos-latest: Apple Silicon
         include:
           - experimental: false
           # macos-latest (Apple Silicon) is experimental
@@ -21,8 +21,12 @@ jobs:
           # Python 3.9 is experimental
           - python-version: '3.9'
             experimental: true
-          # Python 3.13 is experimental
-          - python-version: '3.13'
+          # Python 3.14 is experimental
+          - python-version: '3.14'
+            macos-version: 'macos-14'
+            experimental: true
+          - python-version: '3.14'
+            macos-version: 'macos-latest'
             experimental: true
       fail-fast: false
     runs-on: ${{ matrix.macos-version }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,10 +11,10 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         experimental: [false]
         include:
-          - python-version: '3.13'
+          - python-version: '3.14'
             experimental: true
       fail-fast: false
     runs-on: windows-latest

--- a/toad/impute.py
+++ b/toad/impute.py
@@ -51,6 +51,10 @@ class Imputer(IterativeImputer):
     
 
     def _replace_empty(self, X):
+        X = X.copy()
+        # Convert string columns to object dtype to avoid StringDtype issues in newer pandas
+        for col in X.select_dtypes(include=['string']).columns:
+            X[col] = X[col].astype(object)
         mask = X.isin(self.missing_values_list)
         X = X.where(~mask, np.nan)
         return X, mask
@@ -63,12 +67,14 @@ class Imputer(IterativeImputer):
             mask (Mask): empty mask for X
         """
         category_data = X.select_dtypes(exclude = np.number).columns
-        
+
         for col in category_data:
-            unique, X[col].loc[~mask[col]] = np.unique(X[col][~mask[col]], return_inverse = True)
+            valid = ~mask[col]
+            unique, inverse = np.unique(X.loc[valid, col], return_inverse = True)
+            X.loc[valid, col] = inverse.astype(float)
 
             self.encoder_dict[col] = unique
-        
+
         return X
 
     def _encode(self, X, mask):
@@ -79,9 +85,10 @@ class Imputer(IterativeImputer):
             mask (Mask): empty mask for X
         """
         for col, unique in self.encoder_dict.items():
+            valid = ~mask[col]
             table = dict(zip(unique, np.arange(len(unique))))
-            X[col].loc[~mask[col]] = np.array([table[v] for v in X[col][~mask[col]]])
-        
+            X.loc[valid, col] = np.array([table[v] for v in X.loc[valid, col]]).astype(float)
+
         return X
     
     def _decode(self, X):

--- a/toad/preprocessing/process_test.py
+++ b/toad/preprocessing/process_test.py
@@ -41,7 +41,7 @@ def test_mask_isna():
     assert m.replay(df).sum() == df['A'].isna().sum()
 
 def test_f():
-    assert F(len)(A)[0] == 500
+    assert F(len)(A).iloc[0] == 500
 
 def test_processing():
     res = (

--- a/toad/transform.py
+++ b/toad/transform.py
@@ -100,7 +100,7 @@ class Transformer(TransformerMixin, RulesMixin):
 
     def _check_duplicated_keys(self, X):
         if isinstance(X, pd.DataFrame) and X.columns.has_duplicates:
-            keys = X.columns[X.columns.duplicated()].values
+            keys = X.columns[X.columns.duplicated()].tolist()
             raise Exception("X has duplicate keys `{keys}`".format(keys = str(keys)))
         
         return True

--- a/toad/utils/func_test.py
+++ b/toad/utils/func_test.py
@@ -103,7 +103,7 @@ def test_bin_to_number_for_frame():
         },
     ])
 
-    res = df.applymap(bin_to_number())
+    res = df.map(bin_to_number())
     assert res.loc[1, 'area_2'] == 225
 
 def test_generate_target():


### PR DESCRIPTION
## Summary
- Fix `toad/impute.py` chained assignment (`X[col].loc[~mask]`) that breaks with pandas Copy-on-Write (pandas >= 2.x), replacing with proper `.loc` indexing
- Convert string columns to `object` dtype before processing to avoid `StringDtype` incompatibility with newer pandas
- Replace deprecated `macos-13` runner with `macos-14` in CI workflow
- Promote Python 3.13 from experimental to stable across all CI platforms
- Add Python 3.14 as experimental across all platforms (Linux, macOS, Windows)

## Root Cause
The `test_impute_with_str` test failed on Python 3.11/3.12/3.13 because newer pandas enforces Copy-on-Write and stricter string dtype handling. The chained assignment pattern `X[col].loc[~mask[col]] = value` is no longer supported.

## Test plan
- [ ] All existing tests pass on Python 3.9-3.13 (Linux, macOS, Windows)
- [ ] `test_impute_with_str` specifically passes on Python 3.11+
- [ ] macOS CI runs successfully with `macos-14` runner
- [ ] Python 3.14 experimental jobs run (allowed to fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)